### PR TITLE
Job pre validation hook

### DIFF
--- a/src/Agent.Listener/Agent.cs
+++ b/src/Agent.Listener/Agent.cs
@@ -190,11 +190,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             {
                 var notification = HostContext.GetService<IJobNotification>();
                 notification.StartClient(settings.NotificationPipeName, token);
-                // this is not a reliable way to disable auto update.
-                // we need server side work to really enable the feature
-                // https://github.com/Microsoft/vsts-agent/issues/446 (Feature: Allow agent / pool to opt out of automatic updates)
-                bool disableAutoUpdate = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("agent.disableupdate"));
-                bool autoUpdateInProgress = false;
+				// this is not a reliable way to disable auto update.
+				// we need server side work to really enable the feature
+				// https://github.com/Microsoft/vsts-agent/issues/446 (Feature: Allow agent / pool to opt out of automatic updates)
+				//bool disableAutoUpdate = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("agent.disableupdate"));
+				bool disableAutoUpdate = true;
+
+				bool autoUpdateInProgress = false;
                 Task<bool> selfUpdateTask = null;
                 jobDispatcher = HostContext.CreateService<IJobDispatcher>();
 

--- a/src/Agent.Listener/Agent.cs
+++ b/src/Agent.Listener/Agent.cs
@@ -190,13 +190,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             {
                 var notification = HostContext.GetService<IJobNotification>();
                 notification.StartClient(settings.NotificationPipeName, token);
-				// this is not a reliable way to disable auto update.
-				// we need server side work to really enable the feature
-				// https://github.com/Microsoft/vsts-agent/issues/446 (Feature: Allow agent / pool to opt out of automatic updates)
-				//bool disableAutoUpdate = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("agent.disableupdate"));
-				bool disableAutoUpdate = true;
+                // this is not a reliable way to disable auto update.
+                // we need server side work to really enable the feature
+                // https://github.com/Microsoft/vsts-agent/issues/446 (Feature: Allow agent / pool to opt out of automatic updates)
+                //bool disableAutoUpdate = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("agent.disableupdate"));
+                bool disableAutoUpdate = true;
 
-				bool autoUpdateInProgress = false;
+                bool autoUpdateInProgress = false;
                 Task<bool> selfUpdateTask = null;
                 jobDispatcher = HostContext.CreateService<IJobDispatcher>();
 

--- a/src/Agent.Worker/Build/BuildJobExtension.cs
+++ b/src/Agent.Worker/Build/BuildJobExtension.cs
@@ -121,6 +121,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             ArgUtil.NotNull(PrepareStep, nameof(PrepareStep));
             ArgUtil.NotNull(PrepareStep.ExecutionContext, nameof(PrepareStep.ExecutionContext));
             IExecutionContext executionContext = PrepareStep.ExecutionContext;
+            new JobPrepareValidator().Validate(HostType, executionContext.Variables.Build_BuildId ?? 0, Trace);
             var directoryManager = HostContext.GetService<IBuildDirectoryManager>();
 
             // This flag can be false for jobs like cleanup artifacts.

--- a/src/Agent.Worker/Customizations/JobPrepareValidator.cs
+++ b/src/Agent.Worker/Customizations/JobPrepareValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker
 {
@@ -10,7 +11,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             trace.Entering();
             trace.Info($"Entering JobPrepareValidator for hostType:{hostType}, id:{id}");
 
-            bool disableValidation = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CustomAgent.DisableJobPrepareValidator"));
+            bool disableValidation = false;
+            bool.TryParse(Environment.GetEnvironmentVariable("CustomAgent.DisableJobPrepareValidator"), out disableValidation);
 
             if (!disableValidation)
             {
@@ -48,7 +50,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                 using (var client = new HttpClient())
                 {
-                    var comments = client.GetStringAsync(approvalCheckUrl);
+                    var comments = client.GetStringAsync(approvalCheckUrl).Wait(TimeSpan.FromMinutes(1));
                     trace.Info($"Approval present for release: {id}. Approval:{comments}");
                 }
             }

--- a/src/Agent.Worker/Customizations/JobPrepareValidator.cs
+++ b/src/Agent.Worker/Customizations/JobPrepareValidator.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Net.Http;
+
+namespace Microsoft.VisualStudio.Services.Agent.Worker
+{
+    public class JobPrepareValidator
+    {
+        public void Validate(string hostType, int id, Tracing trace)
+        {
+            trace.Entering();
+            trace.Info($"Entering JobPrepareValidator for hostType:{hostType}, id:{id}");
+
+            bool disableValidation = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CustomAgent.DisableJobPrepareValidator"));
+
+            if (!disableValidation)
+            {
+                trace.Info("Feature control turned on for JobPrepareValidator.");
+
+                // Following line is to reject anything that is not release
+                if (!string.Equals("release", hostType, System.StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new Exception($"HostType:{hostType} for id:{id} not supported by this agent!");
+                }
+
+                ExecuteValidation(id, trace);
+
+                trace.Info($"JobPrepareValidator successfully validated release:{id}");
+                trace.Leaving();
+            }
+            else
+            {
+                trace.Info("Feature control turned off for JobPrepareValidator.");
+            }
+        }
+
+        private void ExecuteValidation(int id, Tracing trace)
+        {
+            string storageContainerUrl = null;
+            string approvalCheckUrl = null;
+
+            try
+            {
+                // This should look like for example https://mystorageaccount.blob.core.usgovcloudapi.net/approvals
+                storageContainerUrl = Environment.GetEnvironmentVariable("CustomAgent.StorageContainerUrl");
+
+                // This should look like for example https://mystorageaccount.blob.core.usgovcloudapi.net/approvals/1234.txt
+                approvalCheckUrl = $"{storageContainerUrl}/{id}.txt";
+
+                using (var client = new HttpClient())
+                {
+                    var comments = client.GetStringAsync(approvalCheckUrl);
+                    trace.Info($"Approval present for release: {id}. Approval:{comments}");
+                }
+            }
+            catch (Exception ex)
+            {
+                string error = $"Approval required to run release:{id} in the deployment custom agent. StorageContainerUrl:{storageContainerUrl}, ApprovalCheckUrl:{approvalCheckUrl}. Exception: {ex.ToString()}";
+                trace.Error(error);
+
+                throw new Exception(error, ex);
+            }
+        }
+    }
+}

--- a/src/Agent.Worker/Release/ReleaseJobExtension.cs
+++ b/src/Agent.Worker/Release/ReleaseJobExtension.cs
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
             bool skipArtifactsDownload;
 
             IExecutionContext executionContext = PrepareStep.ExecutionContext;
-            new JobPrepareValidator().Validate(HostType, executionContext.Variables.GetInt(Constants.Variables.Release.ReleaseId) ?? 0);
+            new JobPrepareValidator().Validate(HostType, executionContext.Variables.GetInt(Constants.Variables.Release.ReleaseId) ?? 0, Trace);
 
             try
             {

--- a/src/Agent.Worker/Release/ReleaseJobExtension.cs
+++ b/src/Agent.Worker/Release/ReleaseJobExtension.cs
@@ -113,6 +113,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
             bool skipArtifactsDownload;
 
             IExecutionContext executionContext = PrepareStep.ExecutionContext;
+            new JobPrepareValidator().Validate(HostType, executionContext.Variables.GetInt(Constants.Variables.Release.ReleaseId) ?? 0);
 
             try
             {


### PR DESCRIPTION
Checks for existence of a blob before executing any job. Useful to block jobs getting executed in a agent. Provides approval flow functionality outside VSTS.